### PR TITLE
Made handling of multiple interfaces async + added filtering functionality.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,9 +1122,11 @@ dependencies = [
 name = "win_can_utils"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "crosscan",
  "ctrlc",
+ "futures",
  "mpsc",
  "named_pipe",
  "ringbuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ mpsc = "0.2.6"
 crosscan = { git = "https://github.com/Cyborg-Dynamics-Engineering/cross-can.git", version = "0.1.0" }
 tokio = { version = "1.47.1", features = ["full", "net"] }
 named_pipe = "0.4.1"
+futures = "0.3.31"
+anyhow = "1.0.99"
 
 [package.metadata.wix]
 eula = "LICENSE.rtf"


### PR DESCRIPTION
Previously, using multipe interfaces would block reading from one another. Added filtering functionality so candump <interface>[,filter] now works similar to can-utils