### PR TITLE
Optimize SLCAN frame parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
  "crosscan",
  "ctrlc",
  "futures",
+ "memchr",
  "mpsc",
  "named_pipe",
  "peak-can-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1.89"
 tokio-serial = "5.4.5"
 bincode = { version = "2.0.1", features = ["serde"] }
 peak-can-sys = "0.1.2"
+memchr = "2.7.4"
 
 [package.metadata.wix]
 eula = "LICENSE.rtf"


### PR DESCRIPTION
## Summary
- avoid per-frame allocations in `SlcanDriver::read_frames` by scanning buffered data with `memchr`
- refactor frame parsing helper to operate on slices and preserve timestamp rollover handling
- add the `memchr` dependency needed for delimiter scanning

## Testing
- cargo check *(fails: missing system library `libudev` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d9e2376c24832d8803397763beb9e8