### PR TITLE
Slcan reader writer split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
  "crosscan",
  "ctrlc",
  "futures",
+ "memchr",
  "mpsc",
  "named_pipe",
  "peak-can-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1.89"
 tokio-serial = "5.4.5"
 bincode = { version = "2.0.1", features = ["serde"] }
 peak-can-sys = "0.1.2"
+memchr = "2.7.4"
 
 [package.metadata.wix]
 eula = "LICENSE.rtf"

--- a/src/bin/canserver.rs
+++ b/src/bin/canserver.rs
@@ -2,7 +2,7 @@ use bincode;
 use clap::Parser;
 use crosscan::can::CanFrame;
 use std::process::exit;
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -175,8 +175,6 @@ async fn main() -> std::io::Result<()> {
             exit(1);
         }
     };
-
-    let shutdown = Arc::new(AtomicBool::new(false));
 
     let (tx_out_pipe, rx_out_pipe) = mpsc::channel::<Vec<u8>>(100);
     let (tx_in_pipe, mut rx_in_pipe) = mpsc::channel::<Vec<u8>>(100);

--- a/src/bin/canserver.rs
+++ b/src/bin/canserver.rs
@@ -2,14 +2,11 @@ use bincode;
 use clap::Parser;
 use crosscan::can::CanFrame;
 use std::process::exit;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, atomic::AtomicBool};
 use tokio::signal;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use tokio::time::{Duration, timeout};
+use tokio::time::Duration;
 use win_can_utils::{CanDriver, PcanDriver, SlcanDriver, thread_manager_async};
 
 #[derive(Parser, Debug)]
@@ -207,6 +204,7 @@ async fn main() -> std::io::Result<()> {
                 if let Err(e) = d.send_frame(&frame).await {
                     eprintln!("Failed to send CAN frame: {:?}", e);
                 }
+                println!("Sent");
             }
         }
         // channel closed → exit loop


### PR DESCRIPTION
Split slcan SerialStream into reader and writer to allow async handling of the functions. This didn't improve performance, but is a better way to handle the functions.