### PR TITLE
Clarify optional PCAN dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,41 @@ This project aims to provide a Windows equivalent of [can-utils](https://github.
 
 
 ## Installation
-Download & run the latest .msi installer from [Releases](https://github.com/Cyborg-Dynamics-Engineering/win-can-utils/releases)
+
+1. Download the latest `.msi` installer from the
+   [Releases](https://github.com/Cyborg-Dynamics-Engineering/win-can-utils/releases) page.
+2. Run the installer and follow the on-screen prompts to complete setup.
+3. If you plan to use a PEAK-System adapter, install the optional
+   `PCANBasic.dll` runtime dependency (see
+   [PCAN-Basic dependency](#pcan-basic-dependency)).
+
+> **Tip:** Administrative privileges are recommended for installing both the
+> application and the supporting drivers.
+
+## PCAN-Basic dependency
+
+PEAK-System CAN adapters require the
+[PCAN-Basic API](https://www.peak-system.com/PCAN-Basic.239.0.html?&L=1)
+runtime library to be present on the system. Other adapters do not use this
+library and can ignore this section. To install the dependency:
+
+1. Download the latest PCAN-Basic package from PEAK-System.
+2. Review and accept the PEAK-System PCAN-Basic End User License Agreement
+   (EULA) during installation. Installation and use of `PCANBasic.dll`
+   indicates that you agree to the terms of the EULA; ensure that your use
+   complies with all PEAK-System licensing requirements.
+3. Extract `PCANBasic.dll` from the package and copy it into the same
+   directory as the Windows CAN Utils executables (or another directory on the
+   system `PATH`).
+4. Restart any running Windows CAN Utils processes to ensure the new DLL is
+   loaded.
+
+You only need to perform these steps once per machine, unless you remove or
+update the DLL in the future.
+
+> **Disclaimer:** Windows CAN Utils is not affiliated with, sponsored by, or
+> endorsed by PEAK-System Technik GmbH. Refer to the PEAK-System licensing
+> terms for permitted usage of their software and hardware.
 
 ## Usage
 ### CAN Server


### PR DESCRIPTION
## Summary
- indicate that PCANBasic.dll is only required when using PEAK-System adapters
- add a disclaimer noting the project is unaffiliated with PEAK-System while reminding users to follow their licensing terms

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68da7df412a0832d83211c8bd82672e5