### PR TITLE
Handle missing PCANBasic.dll gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "libudev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1333,7 @@ dependencies = [
  "env_logger",
  "futures",
  "libc",
+ "libloading",
  "libusb1-sys",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = "0.1.89"
 tokio-serial = "5.4.5"
 bincode = { version = "2.0.1", features = ["serde"] }
 peak-can-sys = "0.1.2"
+libloading = "0.8"
 memchr = "2.7.4"
 libusb1-sys = "0.7"
 libc = "0.2"


### PR DESCRIPTION
## Summary
- load PCANBasic.dll at runtime so the PCAN driver is optional when the DLL is unavailable
- add libloading to resolve the PCAN API symbols dynamically

## Testing
- cargo fmt
- cargo check *(fails: missing system dependency libudev)*

------
https://chatgpt.com/codex/tasks/task_b_68ddf0a72644832d8ee77634d9bb7a16